### PR TITLE
fixed PluginTemplatePlugin.isSitePlugin's @return comment

### DIFF
--- a/PluginTemplatePlugin.inc.php
+++ b/PluginTemplatePlugin.inc.php
@@ -51,7 +51,7 @@ class PluginTemplatePlugin extends GenericPlugin {
 	/**
 	 * Enable the settings form in the site-wide plugins list
 	 *
-	 * @return string
+	 * @return boolean
 	 */
 	public function isSitePlugin() {
 		return true;


### PR DESCRIPTION
`isSitePlugin`'s doc comment claimed to `@return string`, but the method does in fact return `boolean`.